### PR TITLE
Auto-parse parameters from command descriptors (closes #9)

### DIFF
--- a/components/carbon_instrument/CMakeLists.txt
+++ b/components/carbon_instrument/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SRCS
     "carbon_instrument.c"
     "carbon_registry.c"
+    "carbon_param_parser.c"
     "hislip.c"
     "hislip_server.c"
     "scpi_parser.c"

--- a/components/carbon_instrument/carbon_param_parser.c
+++ b/components/carbon_instrument/carbon_param_parser.c
@@ -1,0 +1,183 @@
+#include "carbon_param_parser.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <stdio.h>
+
+/* Advance past spaces, tabs, and commas. */
+static void skip_delimiters(const char **p)
+{
+    while (**p == ' ' || **p == '\t' || **p == ',') (*p)++;
+}
+
+/* Copy the next space/comma-delimited token into buf[buflen].
+   Advances *p past the token (but not past the following delimiter).
+   Returns false if the string is empty after skipping leading delimiters. */
+static bool next_token(const char **p, char *buf, size_t buflen)
+{
+    skip_delimiters(p);
+    if (**p == '\0') return false;
+    size_t i = 0;
+    while (**p && **p != ' ' && **p != '\t' && **p != ',') {
+        if (i < buflen - 1) buf[i++] = **p;
+        (*p)++;
+    }
+    buf[i] = '\0';
+    return true;
+}
+
+/* Copy the remainder of p into buf[buflen], stripping trailing whitespace.
+   Used for a STRING param that is the last (or only) parameter, so the full
+   remaining text (spaces included) is the value. */
+static void rest_trimmed(const char *p, char *buf, size_t buflen)
+{
+    while (*p == ' ' || *p == '\t') p++;
+    size_t len = strlen(p);
+    while (len > 0 && (p[len-1] == ' ' || p[len-1] == '\t' ||
+                        p[len-1] == '\r' || p[len-1] == '\n')) {
+        len--;
+    }
+    if (len >= buflen) len = buflen - 1;
+    memcpy(buf, p, len);
+    buf[len] = '\0';
+}
+
+int carbon_parse_params(const char *cmd_tail,
+                        const carbon_param_t *descs,
+                        int desc_count,
+                        carbon_parsed_param_t *out,
+                        char *str_scratch,
+                        size_t scratch_len,
+                        char *response_buf,
+                        size_t response_max)
+{
+    if (desc_count == 0) return 0;
+    if (!cmd_tail) cmd_tail = "";
+
+    const char *pos = cmd_tail;
+    size_t scratch_used = 0;
+
+    for (int i = 0; i < desc_count; i++) {
+        const carbon_param_t *d = &descs[i];
+        char token[256];
+        bool have_token;
+
+        /* A STRING that is the last parameter consumes the rest of the line so
+           spaces within the value are preserved. */
+        if (d->type == CARBON_PARAM_STRING && i == desc_count - 1) {
+            rest_trimmed(pos, token, sizeof(token));
+            have_token = (token[0] != '\0');
+        } else {
+            have_token = next_token(&pos, token, sizeof(token));
+        }
+
+        if (!have_token || token[0] == '\0') {
+            if (d->default_value) {
+                strncpy(token, d->default_value, sizeof(token) - 1);
+                token[sizeof(token) - 1] = '\0';
+            } else {
+                snprintf(response_buf, response_max,
+                         "ERROR: Missing required parameter '%s'", d->name);
+                return -1;
+            }
+        }
+
+        out[i].name = d->name;
+        out[i].type = d->type;
+
+        switch (d->type) {
+            case CARBON_PARAM_INT: {
+                char *end;
+                long v = strtol(token, &end, 10);
+                if (end == token || *end != '\0') {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': expected integer, got '%s'",
+                             d->name, token);
+                    return -1;
+                }
+                if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': %ld out of range [%.0f, %.0f]",
+                             d->name, v, d->min, d->max);
+                    return -1;
+                }
+                out[i].int_val = (int)v;
+                break;
+            }
+            case CARBON_PARAM_FLOAT: {
+                char *end;
+                float v = strtof(token, &end);
+                if (end == token || *end != '\0') {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': expected float, got '%s'",
+                             d->name, token);
+                    return -1;
+                }
+                if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': %g out of range [%g, %g]",
+                             d->name, (double)v, d->min, d->max);
+                    return -1;
+                }
+                out[i].float_val = v;
+                break;
+            }
+            case CARBON_PARAM_BOOL: {
+                bool bv;
+                if (strcasecmp(token, "1") == 0 || strcasecmp(token, "true") == 0 ||
+                    strcasecmp(token, "on") == 0  || strcasecmp(token, "yes") == 0) {
+                    bv = true;
+                } else if (strcasecmp(token, "0") == 0 || strcasecmp(token, "false") == 0 ||
+                           strcasecmp(token, "off") == 0 || strcasecmp(token, "no") == 0) {
+                    bv = false;
+                } else {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': expected boolean (0/1/true/false/on/off),"
+                             " got '%s'", d->name, token);
+                    return -1;
+                }
+                out[i].bool_val = bv;
+                break;
+            }
+            case CARBON_PARAM_STRING: {
+                size_t len = strlen(token) + 1;
+                if (scratch_used + len > scratch_len) {
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': string too long", d->name);
+                    return -1;
+                }
+                memcpy(str_scratch + scratch_used, token, len);
+                out[i].str_val = str_scratch + scratch_used;
+                scratch_used += len;
+                break;
+            }
+            case CARBON_PARAM_ENUM: {
+                int matched = -1;
+                for (int j = 0; j < d->enum_count; j++) {
+                    if (strcasecmp(token, d->enum_values[j]) == 0) {
+                        matched = j;
+                        break;
+                    }
+                }
+                if (matched < 0) {
+                    /* Build a readable list of valid choices for the error message. */
+                    char valid[128] = "";
+                    for (int j = 0; j < d->enum_count; j++) {
+                        if (j > 0)
+                            strncat(valid, "|", sizeof(valid) - strlen(valid) - 1);
+                        strncat(valid, d->enum_values[j], sizeof(valid) - strlen(valid) - 1);
+                    }
+                    snprintf(response_buf, response_max,
+                             "ERROR: Parameter '%s': expected %s, got '%s'",
+                             d->name, valid, token);
+                    return -1;
+                }
+                out[i].int_val = matched;
+                break;
+            }
+        }
+    }
+    return desc_count;
+}

--- a/components/carbon_instrument/carbon_param_parser.h
+++ b/components/carbon_instrument/carbon_param_parser.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "carbon_instrument.h"
+#include <stddef.h>
+
+// Parse parameters from the tail of a command string (everything after "CMD_NAME ").
+// Each descriptor in descs[0..desc_count-1] drives type conversion and range validation.
+// Parsed values are written to out[0..desc_count-1].
+// STRING values are copied into str_scratch; str_val pointers remain valid as long as
+// str_scratch is live (i.e. for the duration of the handler call).
+// On parse or validation error, writes a human-readable message to response_buf and returns < 0.
+// On success, returns the number of parameters parsed (== desc_count).
+int carbon_parse_params(const char *cmd_tail,
+                        const carbon_param_t *descs,
+                        int desc_count,
+                        carbon_parsed_param_t *out,
+                        char *str_scratch,
+                        size_t scratch_len,
+                        char *response_buf,
+                        size_t response_max);

--- a/components/carbon_instrument/include/carbon_instrument.h
+++ b/components/carbon_instrument/include/carbon_instrument.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esp_err.h"
+#include <stdbool.h>
 #include <stddef.h>
 
 #define CARBON_MAX_PARAMS      8
@@ -25,6 +26,26 @@ typedef enum {
 // returns: byte length of response written (0 = no response)
 typedef int (*carbon_cmd_handler_t)(const char *cmd, char *response, size_t response_max);
 
+// Parsed value for a single parameter, populated by the SDK before handler_v2 is called.
+// For CARBON_PARAM_ENUM, int_val holds the matched index into descriptor->enum_values[].
+typedef struct {
+    const char         *name;
+    carbon_param_type_t type;
+    union {
+        int         int_val;
+        float       float_val;
+        bool        bool_val;
+        const char *str_val;
+    };
+} carbon_parsed_param_t;
+
+// params: array of parsed parameters (length == param_count from descriptor)
+// returns: byte length of response written (0 = no response)
+typedef int (*carbon_cmd_handler_v2_t)(const carbon_parsed_param_t *params,
+                                       int param_count,
+                                       char *response,
+                                       size_t response_max);
+
 typedef struct {
     const char         *name;
     carbon_param_type_t type;
@@ -37,14 +58,15 @@ typedef struct {
 } carbon_param_t;
 
 typedef struct {
-    const char           *scpi_command;  // uppercase mnemonic, e.g. "GPIO:SET" or "*IDN?"
-    carbon_cmd_type_t     type;
-    const char           *group;
-    const char           *description;
-    carbon_param_t        params[CARBON_MAX_PARAMS];
-    int                   param_count;
-    int                   timeout_ms;
-    carbon_cmd_handler_t  handler;
+    const char             *scpi_command;  // uppercase mnemonic, e.g. "GPIO:SET" or "*IDN?"
+    carbon_cmd_type_t       type;
+    const char             *group;
+    const char             *description;
+    carbon_param_t          params[CARBON_MAX_PARAMS];
+    int                     param_count;
+    int                     timeout_ms;
+    carbon_cmd_handler_t    handler;    // set this OR handler_v2, not both
+    carbon_cmd_handler_v2_t handler_v2; // SDK parses params before calling; NULL = use handler
 } carbon_cmd_descriptor_t;
 
 // Device identity. Any NULL field falls back to the Kconfig/firmware default.

--- a/components/carbon_instrument/scpi_gpio.c
+++ b/components/carbon_instrument/scpi_gpio.c
@@ -19,15 +19,17 @@ static bool is_valid_pin(int pin)
     }
 }
 
-static int gpio_set_handler(const char *cmd, char *r, size_t n)
+static int gpio_set_handler_v2(const carbon_parsed_param_t *params, int param_count,
+                               char *r, size_t n)
 {
-    int pin, value;
-    if (sscanf(cmd + 9, "%d %d", &pin, &value) != 2) {
-        snprintf(r, n, "ERROR: Invalid GPIO:SET syntax");
+    (void)param_count;
+    int pin   = params[0].int_val;
+    int value = params[1].int_val;
+    /* Range (2-33) already validated by the SDK; check for safe writable pins. */
+    if (!is_valid_pin(pin)) {
+        snprintf(r, n, "ERROR: Invalid pin %d", pin);
         return strlen(r);
     }
-    if (!is_valid_pin(pin)) { snprintf(r, n, "ERROR: Invalid pin %d", pin); return strlen(r); }
-    if (value != 0 && value != 1) { snprintf(r, n, "ERROR: Value must be 0 or 1"); return strlen(r); }
     gpio_set_direction(pin, GPIO_MODE_INPUT_OUTPUT);
     gpio_set_level(pin, value);
     ESP_LOGI(TAG, "GPIO%d = %d", pin, value);
@@ -82,7 +84,7 @@ void scpi_gpio_init(void)
             },
             .param_count  = 2,
             .timeout_ms   = 100,
-            .handler      = gpio_set_handler,
+            .handler_v2   = gpio_set_handler_v2,
         },
         {
             .scpi_command = "GPIO:GET?",

--- a/components/carbon_instrument/scpi_watchdog.c
+++ b/components/carbon_instrument/scpi_watchdog.c
@@ -1,4 +1,5 @@
 #include "scpi_watchdog.h"
+#include "carbon_param_parser.h"
 
 #include "freertos/FreeRTOS.h"
 #if configUSE_TIMERS != 1
@@ -30,10 +31,30 @@ typedef struct {
     TaskHandle_t                   handler_task;
 } watchdog_ctx_t;
 
+/* Dispatch to handler_v2 (with SDK-parsed params) or fall through to handler (raw string). */
+static int invoke_handler(const carbon_cmd_descriptor_t *desc,
+                          const char *cmd,
+                          char *response_buf,
+                          size_t response_max_len)
+{
+    if (desc->handler_v2) {
+        carbon_parsed_param_t parsed[CARBON_MAX_PARAMS];
+        char str_scratch[256];
+        const char *tail = cmd + strlen(desc->scpi_command);
+        while (*tail == ' ' || *tail == '\t') tail++;
+        int n = carbon_parse_params(tail, desc->params, desc->param_count,
+                                    parsed, str_scratch, sizeof(str_scratch),
+                                    response_buf, response_max_len);
+        if (n < 0) return (int)strlen(response_buf);
+        return desc->handler_v2(parsed, n, response_buf, response_max_len);
+    }
+    return desc->handler(cmd, response_buf, response_max_len);
+}
+
 static void handler_task_fn(void *arg)
 {
     watchdog_ctx_t *ctx = arg;
-    ctx->result = ctx->desc->handler(ctx->cmd, ctx->response_buf, ctx->response_max_len);
+    ctx->result = invoke_handler(ctx->desc, ctx->cmd, ctx->response_buf, ctx->response_max_len);
     xTaskNotify(ctx->caller_task, DONE_BIT, eSetBits);
     vTaskSuspend(NULL);
 }
@@ -55,7 +76,7 @@ int scpi_watchdog_dispatch(const carbon_cmd_descriptor_t *desc,
 
     watchdog_ctx_t *ctx = malloc(sizeof(watchdog_ctx_t));
     if (!ctx) {
-        return desc->handler(cmd, response_buf, response_max_len);
+        return invoke_handler(desc, cmd, response_buf, response_max_len);
     }
     ctx->desc            = desc;
     ctx->cmd             = cmd;
@@ -69,7 +90,7 @@ int scpi_watchdog_dispatch(const carbon_cmd_descriptor_t *desc,
                                        pdFALSE, ctx, watchdog_cb);
     if (!timer) {
         free(ctx);
-        return desc->handler(cmd, response_buf, response_max_len);
+        return invoke_handler(desc, cmd, response_buf, response_max_len);
     }
 
     if (xTaskCreate(handler_task_fn, "cmd_handler",
@@ -77,7 +98,7 @@ int scpi_watchdog_dispatch(const carbon_cmd_descriptor_t *desc,
                     ctx, uxTaskPriorityGet(NULL), &ctx->handler_task) != pdPASS) {
         xTimerDelete(timer, 0);
         free(ctx);
-        return desc->handler(cmd, response_buf, response_max_len);
+        return invoke_handler(desc, cmd, response_buf, response_max_len);
     }
 
     xTimerStart(timer, 0);


### PR DESCRIPTION
## Summary

- Adds `carbon_parsed_param_t` (union-based struct) and `carbon_cmd_handler_v2_t` to the public API
- Adds `handler_v2` field to `carbon_cmd_descriptor_t`; setting it opts a command into SDK-level parsing — existing `handler` registrations are untouched (no breaking change)
- New `carbon_param_parser.c` tokenises the command tail by space/comma and converts each token according to its descriptor type: `INT` (`strtol`), `FLOAT` (`strtof`), `BOOL` (accepts `0/1/true/false/on/off`), `STRING` (last-param captures rest of line to preserve spaces), `ENUM` (case-insensitive match, stores matched index as `int_val`)
- Range validation (`min`/`max`) is enforced before the handler is called; on failure a human-readable `ERROR:` message is written to the response buffer automatically
- `scpi_watchdog.c` gained an `invoke_handler()` helper that dispatches to `handler_v2` (with parsed params) or falls through to `handler` (raw string); all three watchdog fallback paths use the same helper
- `GPIO:SET` converted to `handler_v2` as the reference example — `sscanf` + pointer arithmetic replaced by `params[0].int_val` / `params[1].int_val`

## Test plan

- [ ] Build the component with `idf.py build` — zero new warnings
- [ ] Send `GPIO:SET 22 1` via HiSLIP — pin goes high, response is `OK`
- [ ] Send `GPIO:SET 99 1` — response is `ERROR: Parameter 'pin': 99 out of range [2, 33]` (parser rejects before handler runs)
- [ ] Send `GPIO:SET abc 1` — response is `ERROR: Parameter 'pin': expected integer, got 'abc'`
- [ ] Send `GPIO:GET? 22` (v1 handler) — still works, returns `0` or `1`
- [ ] Confirm `SYSTEM:COMMANDS?` still returns full metadata for all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)