### PR TITLE
Add typed response formatting helpers (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ Include `carbon_instrument.h`, write your handler, declare a descriptor, registe
 
 ```c
 #include "carbon_instrument.h"
-#include <stdio.h>
-#include <string.h>
+#include "carbon_response.h"
 
 // Handler receives the full normalized SCPI string and writes the response.
 // Returns the byte length of the response (0 = no response).
@@ -121,15 +120,13 @@ static int pump_speed_handler(const char *cmd, char *r, size_t n)
     int speed;
     sscanf(cmd + 11, "%d", &speed);  // skip "PUMP:SPEED "
     set_pump_pwm(speed);             // your hardware call
-    snprintf(r, n, "OK");
-    return strlen(r);
+    return carbon_respond_enum(r, n, "OK");
 }
 
 static int temp_read_handler(const char *cmd, char *r, size_t n)
 {
-    float temp = read_temperature_sensor();  // your hardware call
-    snprintf(r, n, "%.2f", temp);
-    return strlen(r);
+    double temp = read_temperature_sensor();  // your hardware call
+    return carbon_respond_float(r, n, temp);
 }
 
 void register_my_commands(void)
@@ -215,6 +212,33 @@ carbon_register_command(&my_cmd);
 carbon_cmd_descriptor_t my_cmd = { ... };  // no static
 carbon_register_command(&my_cmd);
 ```
+
+## Response Formatting
+
+Include `carbon_response.h` to format handler responses in a format that Carbon's daemon can reliably parse into a `TypedValue`. Using raw `snprintf` is error-prone — the daemon may fail to parse the result silently.
+
+| Helper | TypedValue type | Output example |
+|--------|----------------|----------------|
+| `carbon_respond_float(r, n, 3.3)` | `float_value` | `"3.3"` |
+| `carbon_respond_int(r, n, 42)` | `int_value` | `"42"` |
+| `carbon_respond_bool(r, n, true)` | `bool_value` | `"1"` |
+| `carbon_respond_enum(r, n, "RISING")` | `enum_value` | `"RISING"` |
+| `carbon_respond_float_array(r, n, samples, 10)` | `float_array` | `"1.0,2.5,3.0,..."` |
+| `carbon_respond_error(r, n, 2, "invalid pin")` | _(error field)_ | `"ERR:2:invalid pin"` |
+
+All helpers return `strlen(resp)`, matching the handler return convention, and null-terminate on truncation. Use a buffer of at least 256 bytes (the SDK guarantees this for all handler calls).
+
+**Do not include physical units in the response string.** Units belong in the instrument profile's `response.unit` field:
+
+```c
+// Wrong — daemon cannot parse this as a float
+snprintf(r, n, "%.3f V", voltage);
+
+// Correct — unit goes in profile YAML, not here
+return carbon_respond_float(r, n, voltage);
+```
+
+Error codes convention: `1` = missing parameter, `2` = invalid argument, `3` = hardware failure.
 
 ## Built-in Commands
 

--- a/components/carbon_instrument/CMakeLists.txt
+++ b/components/carbon_instrument/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SRCS
     "carbon_instrument.c"
     "carbon_registry.c"
     "carbon_param_parser.c"
+    "carbon_response.c"
     "hislip.c"
     "hislip_server.c"
     "scpi_parser.c"

--- a/components/carbon_instrument/carbon_param_parser.c
+++ b/components/carbon_instrument/carbon_param_parser.c
@@ -79,7 +79,7 @@ int carbon_parse_params(const char *cmd_tail,
                 token[sizeof(token) - 1] = '\0';
             } else {
                 snprintf(response_buf, response_max,
-                         "ERROR: Missing required parameter '%s'", d->name);
+                         "ERR:1:missing required parameter '%s'", d->name);
                 return -1;
             }
         }
@@ -93,13 +93,13 @@ int carbon_parse_params(const char *cmd_tail,
                 long v = strtol(token, &end, 10);
                 if (end == token || *end != '\0') {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': expected integer, got '%s'",
+                             "ERR:2:parameter '%s': expected integer, got '%s'",
                              d->name, token);
                     return -1;
                 }
                 if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': %ld out of range [%.0f, %.0f]",
+                             "ERR:3:parameter '%s': %ld out of range [%.0f, %.0f]",
                              d->name, v, d->min, d->max);
                     return -1;
                 }
@@ -111,13 +111,13 @@ int carbon_parse_params(const char *cmd_tail,
                 float v = strtof(token, &end);
                 if (end == token || *end != '\0') {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': expected float, got '%s'",
+                             "ERR:2:parameter '%s': expected float, got '%s'",
                              d->name, token);
                     return -1;
                 }
                 if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': %g out of range [%g, %g]",
+                             "ERR:3:parameter '%s': %g out of range [%g, %g]",
                              d->name, (double)v, d->min, d->max);
                     return -1;
                 }
@@ -134,7 +134,7 @@ int carbon_parse_params(const char *cmd_tail,
                     bv = false;
                 } else {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': expected boolean (0/1/true/false/on/off),"
+                             "ERR:2:parameter '%s': expected boolean (0/1/true/false/on/off),"
                              " got '%s'", d->name, token);
                     return -1;
                 }
@@ -145,7 +145,7 @@ int carbon_parse_params(const char *cmd_tail,
                 size_t len = strlen(token) + 1;
                 if (scratch_used + len > scratch_len) {
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': string too long", d->name);
+                             "ERR:2:parameter '%s': string too long", d->name);
                     return -1;
                 }
                 memcpy(str_scratch + scratch_used, token, len);
@@ -170,7 +170,7 @@ int carbon_parse_params(const char *cmd_tail,
                         strncat(valid, d->enum_values[j], sizeof(valid) - strlen(valid) - 1);
                     }
                     snprintf(response_buf, response_max,
-                             "ERROR: Parameter '%s': expected %s, got '%s'",
+                             "ERR:2:parameter '%s': expected %s, got '%s'",
                              d->name, valid, token);
                     return -1;
                 }

--- a/components/carbon_instrument/carbon_response.c
+++ b/components/carbon_instrument/carbon_response.c
@@ -1,0 +1,55 @@
+#include "carbon_response.h"
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+int carbon_respond_float(char *resp, size_t n, double value)
+{
+    snprintf(resp, n, "%.6g", value);
+    return (int)strlen(resp);
+}
+
+int carbon_respond_int(char *resp, size_t n, int64_t value)
+{
+    snprintf(resp, n, "%" PRId64, value);
+    return (int)strlen(resp);
+}
+
+int carbon_respond_bool(char *resp, size_t n, bool value)
+{
+    snprintf(resp, n, "%d", value ? 1 : 0);
+    return (int)strlen(resp);
+}
+
+int carbon_respond_enum(char *resp, size_t n, const char *value)
+{
+    if (!value) value = "";
+    snprintf(resp, n, "%s", value);
+    return (int)strlen(resp);
+}
+
+int carbon_respond_float_array(char *resp, size_t n, const double *values, int count)
+{
+    if (n == 0) return 0;
+    size_t pos = 0;
+    for (int i = 0; i < count; i++) {
+        int written = snprintf(resp + pos, n - pos, "%s%.6g",
+                               i > 0 ? "," : "", values[i]);
+        if (written < 0 || (size_t)written >= n - pos) {
+            resp[n - 1] = '\0';
+            break;
+        }
+        pos += (size_t)written;
+    }
+    return (int)strlen(resp);
+}
+
+int carbon_respond_error(char *resp, size_t n, int code, const char *message)
+{
+    if (!message) message = "";
+    int written = snprintf(resp, n, "ERR:%d:%s", code, message);
+    if (written < 0 || (size_t)written >= n) {
+        if (n > 0) resp[n - 1] = '\0';
+    }
+    return (int)strlen(resp);
+}

--- a/components/carbon_instrument/include/carbon_response.h
+++ b/components/carbon_instrument/include/carbon_response.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// Typed response helpers for Carbon instrument handlers.
+//
+// Each helper writes a daemon-parseable string into resp[0..n-1] and returns
+// strlen(resp) — matching the handler return convention.  All helpers
+// null-terminate the buffer even on truncation.
+//
+// Recommended minimum buffer size: 256 bytes.  The response buffer passed to
+// handlers by the SDK is always at least that large.
+//
+// IMPORTANT: Do NOT include physical units in the response string.  Units
+// belong in the instrument profile's response.unit field, not here.
+
+// Formats a double as a bare decimal string (e.g. "3.3") parseable as TypedValue float_value.
+int carbon_respond_float(char *resp, size_t n, double value);
+
+// Formats a 64-bit integer (e.g. "42") parseable as TypedValue int_value.
+int carbon_respond_int(char *resp, size_t n, int64_t value);
+
+// Formats a boolean as "1" or "0" parseable as TypedValue bool_value.
+// carbond accepts "1"/"ON" for true and "0"/"OFF" for false — not "true"/"false".
+int carbon_respond_bool(char *resp, size_t n, bool value);
+
+// Copies value verbatim; parseable as TypedValue enum_value.  NULL value treated as "".
+int carbon_respond_enum(char *resp, size_t n, const char *value);
+
+// Formats values as comma-separated decimals (e.g. "1.0,2.5,3.0") parseable as
+// TypedValue float_array using carbond's default "," delimiter.
+// On buffer overflow, stops after the last fully written element.
+int carbon_respond_float_array(char *resp, size_t n, const double *values, int count);
+
+// Formats a structured error: "ERR:<code>:<message>".
+// Errors surface in CommandResponse.error and are not parsed as a TypedValue.
+// NULL message treated as "".  On truncation, the buffer is null-terminated.
+int carbon_respond_error(char *resp, size_t n, int code, const char *message);

--- a/components/carbon_instrument/scpi_adc.c
+++ b/components/carbon_instrument/scpi_adc.c
@@ -1,4 +1,5 @@
 #include "carbon_instrument.h"
+#include "carbon_response.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_adc/adc_oneshot.h"
@@ -16,18 +17,15 @@ static bool adc_initialized = false;
 static int adc_read_handler(const char *cmd, char *r, size_t n)
 {
     if (!adc_initialized || adc1_handle == NULL || adc1_cali_handle == NULL) {
-        snprintf(r, n, "ERROR: ADC not initialized");
-        return strlen(r);
+        return carbon_respond_error(r, n, 1, "ADC not initialized");
     }
 
     int channel;
     if (sscanf(cmd + 10, "%d", &channel) != 1) {
-        snprintf(r, n, "ERROR: Invalid ADC:READ? syntax");
-        return strlen(r);
+        return carbon_respond_error(r, n, 2, "invalid ADC:READ? syntax");
     }
     if (channel < 0 || channel > 7) {
-        snprintf(r, n, "ERROR: Channel must be 0-7");
-        return strlen(r);
+        return carbon_respond_error(r, n, 2, "channel must be 0-7");
     }
 
     adc_channel_t adc_channel;
@@ -40,7 +38,7 @@ static int adc_read_handler(const char *cmd, char *r, size_t n)
         case 5: adc_channel = ADC_CHANNEL_5; break;
         case 6: adc_channel = ADC_CHANNEL_6; break;
         case 7: adc_channel = ADC_CHANNEL_7; break;
-        default: snprintf(r, n, "ERROR: Invalid channel"); return strlen(r);
+        default: return carbon_respond_error(r, n, 2, "invalid channel");
     }
 
     adc_oneshot_chan_cfg_t config = {
@@ -48,26 +46,22 @@ static int adc_read_handler(const char *cmd, char *r, size_t n)
         .atten    = ADC_ATTEN_DB_12,
     };
     if (adc_oneshot_config_channel(adc1_handle, adc_channel, &config) != ESP_OK) {
-        snprintf(r, n, "ERROR: ADC channel config failed");
-        return strlen(r);
+        return carbon_respond_error(r, n, 3, "ADC channel config failed");
     }
 
     int raw = 0;
     if (adc_oneshot_read(adc1_handle, adc_channel, &raw) != ESP_OK) {
-        snprintf(r, n, "ERROR: ADC read failed");
-        return strlen(r);
+        return carbon_respond_error(r, n, 3, "ADC read failed");
     }
 
     int voltage_mv = 0;
     if (adc_cali_raw_to_voltage(adc1_cali_handle, raw, &voltage_mv) != ESP_OK) {
-        snprintf(r, n, "ERROR: ADC calibration failed");
-        return strlen(r);
+        return carbon_respond_error(r, n, 3, "ADC calibration failed");
     }
 
-    float voltage_v = voltage_mv / 1000.0f;
-    snprintf(r, n, "%.3f", voltage_v);
+    double voltage_v = voltage_mv / 1000.0;
     ESP_LOGI(TAG, "ADC ch%d: %d mV", channel, voltage_mv);
-    return strlen(r);
+    return carbon_respond_float(r, n, voltage_v);
 }
 
 void scpi_adc_init(void)

--- a/components/carbon_instrument/scpi_gpio.c
+++ b/components/carbon_instrument/scpi_gpio.c
@@ -1,4 +1,5 @@
 #include "carbon_instrument.h"
+#include "carbon_response.h"
 #include <string.h>
 #include <strings.h>
 #include <stdio.h>
@@ -27,26 +28,22 @@ static int gpio_set_handler_v2(const carbon_parsed_param_t *params, int param_co
     int value = params[1].int_val;
     /* Range (2-33) already validated by the SDK; check for safe writable pins. */
     if (!is_valid_pin(pin)) {
-        snprintf(r, n, "ERROR: Invalid pin %d", pin);
-        return strlen(r);
+        return carbon_respond_error(r, n, 2, "invalid pin");
     }
     gpio_set_direction(pin, GPIO_MODE_INPUT_OUTPUT);
     gpio_set_level(pin, value);
     ESP_LOGI(TAG, "GPIO%d = %d", pin, value);
-    snprintf(r, n, "OK");
-    return strlen(r);
+    return carbon_respond_enum(r, n, "OK");
 }
 
 static int gpio_get_handler(const char *cmd, char *r, size_t n)
 {
     int pin;
     if (sscanf(cmd + 10, "%d", &pin) != 1) {
-        snprintf(r, n, "ERROR: Invalid GPIO:GET? syntax");
-        return strlen(r);
+        return carbon_respond_error(r, n, 2, "invalid GPIO:GET? syntax");
     }
-    if (!is_valid_pin(pin)) { snprintf(r, n, "ERROR: Invalid pin %d", pin); return strlen(r); }
-    snprintf(r, n, "%d", gpio_get_level(pin));
-    return strlen(r);
+    if (!is_valid_pin(pin)) { return carbon_respond_error(r, n, 2, "invalid pin"); }
+    return carbon_respond_int(r, n, gpio_get_level(pin));
 }
 
 static int gpio_config_handler(const char *cmd, char *r, size_t n)
@@ -54,18 +51,16 @@ static int gpio_config_handler(const char *cmd, char *r, size_t n)
     int pin;
     char mode_str[16];
     if (sscanf(cmd + 12, "%d %15s", &pin, mode_str) != 2) {
-        snprintf(r, n, "ERROR: Invalid GPIO:CONFIG syntax");
-        return strlen(r);
+        return carbon_respond_error(r, n, 2, "invalid GPIO:CONFIG syntax");
     }
-    if (!is_valid_pin(pin)) { snprintf(r, n, "ERROR: Invalid pin %d", pin); return strlen(r); }
+    if (!is_valid_pin(pin)) { return carbon_respond_error(r, n, 2, "invalid pin"); }
     gpio_mode_t mode;
     if (strcasecmp(mode_str, "INPUT") == 0)       mode = GPIO_MODE_INPUT;
     else if (strcasecmp(mode_str, "OUTPUT") == 0) mode = GPIO_MODE_INPUT_OUTPUT;
-    else { snprintf(r, n, "ERROR: Mode must be INPUT or OUTPUT"); return strlen(r); }
+    else { return carbon_respond_error(r, n, 2, "mode must be INPUT or OUTPUT"); }
     gpio_set_direction(pin, mode);
     ESP_LOGI(TAG, "GPIO%d configured as %s", pin, mode_str);
-    snprintf(r, n, "OK");
-    return strlen(r);
+    return carbon_respond_enum(r, n, "OK");
 }
 
 void scpi_gpio_init(void)

--- a/components/carbon_instrument/scpi_watchdog.c
+++ b/components/carbon_instrument/scpi_watchdog.c
@@ -1,5 +1,6 @@
 #include "scpi_watchdog.h"
 #include "carbon_param_parser.h"
+#include "carbon_response.h"
 
 #include "freertos/FreeRTOS.h"
 #if configUSE_TIMERS != 1
@@ -121,8 +122,7 @@ int scpi_watchdog_dispatch(const carbon_cmd_descriptor_t *desc,
     } else {
         ESP_LOGW(TAG, "Command '%s' timed out after %d ms",
                  desc->scpi_command, timeout_ms);
-        ret = snprintf(response_buf, response_max_len, "-365,\"Time out error\"");
-        if (ret < 0) ret = 0;
+        ret = carbon_respond_error(response_buf, response_max_len, -365, "Time out error");
     }
 
     free(ctx);

--- a/examples/hello_world/main/hello_world_example.c
+++ b/examples/hello_world/main/hello_world_example.c
@@ -17,6 +17,7 @@
 #include "esp_event.h"
 
 #include "carbon_instrument.h"
+#include "carbon_response.h"
 
 static const char *TAG = "hello_world";
 
@@ -47,9 +48,9 @@ static int cmd_greet_name(const char *cmd, char *r, size_t n)
 
 static int cmd_counter(const char *cmd, char *r, size_t n)
 {
-    static uint32_t count = 0;
+    static int64_t count = 0;
     count++;
-    return snprintf(r, n, "%lu", (unsigned long)count);
+    return carbon_respond_int(r, n, count);
 }
 
 // cmd arrives as: ECHO "your message"


### PR DESCRIPTION
Closes #11

## Summary

- Adds `carbon_response.h` / `carbon_response.c` with six typed helpers (`carbon_respond_float`, `_int`, `_bool`, `_enum`, `_float_array`, `_error`) whose wire formats are verified against `carbond`'s `profiles.rs::parse_response`
- Migrates `scpi_adc.c`, `scpi_gpio.c`, `carbon_param_parser.c`, and `scpi_watchdog.c` off freeform `snprintf` to enforce the format contract at the source
- Adds a "Response Formatting" section to `README.md` and updates the "Adding Custom Commands" examples to use the helpers

**Key design decisions:**
- `carbon_respond_float` takes no unit parameter — units belong in the instrument profile's `response.unit` field, not the raw response string (verified against carbond)
- `carbon_respond_bool` emits `"1"`/`"0"` — carbond rejects `"true"`/`"false"` (verified)
- Error codes convention: `1` = missing parameter, `2` = invalid argument, `3` = hardware failure, `-365` = timeout (SCPI standard)

## Test plan

- [ ] Flash to an ESP32 and confirm `ADC:READ? 0` returns a bare decimal (e.g. `"3.3"`) with no unit suffix
- [ ] Confirm `GPIO:GET? 2` returns `"0"` or `"1"` (not `"false"`/`"true"`)
- [ ] Confirm `GPIO:SET 2 1` returns `"OK"`
- [ ] Confirm `GPIO:SET 99 1` returns `"ERR:2:invalid pin"` (not `"ERROR: Invalid pin 99"`)
- [ ] Confirm `ADC:READ? 99` returns `"ERR:2:channel must be 0-7"`
- [ ] Run `test_hislip_client.py` — all existing tests should pass
- [ ] Pass a command with a missing required parameter and confirm the response is `"ERR:1:missing required parameter '<name>'"` (not `"ERROR: Missing..."`)
- [ ] Let a command time out (set `timeout_ms` very low) and confirm response is `"ERR:-365:Time out error"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)