### PR TITLE
Implement SCPI error queue (SYST:ERR?)

### DIFF
--- a/components/carbon_instrument/CMakeLists.txt
+++ b/components/carbon_instrument/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRCS
     "carbon_instrument.c"
+    "carbon_error_queue.c"
     "carbon_registry.c"
     "carbon_param_parser.c"
     "carbon_response.c"

--- a/components/carbon_instrument/Kconfig
+++ b/components/carbon_instrument/Kconfig
@@ -47,4 +47,12 @@ menu "Carbon Instrument SDK"
             overlap mode. Each slot holds a pointer (not an inline buffer),
             so RAM cost is small. Increase if your client pipelines deeply.
 
+    config CARBON_ERROR_QUEUE_SIZE
+        int "SCPI error queue depth"
+        default 16
+        range 4 64
+        help
+            Number of errors stored in the SCPI error queue (SYST:ERR?).
+            Each entry uses 68 bytes (4-byte code + 64-byte message).
+
 endmenu

--- a/components/carbon_instrument/carbon_error_queue.c
+++ b/components/carbon_instrument/carbon_error_queue.c
@@ -1,0 +1,112 @@
+#include "carbon_error_queue.h"
+
+#include <string.h>
+#include <stdio.h>
+#include "sdkconfig.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "esp_log.h"
+
+static const char *TAG = "carbon_err_queue";
+
+#ifdef CONFIG_CARBON_ERROR_QUEUE_SIZE
+#define QUEUE_SIZE CONFIG_CARBON_ERROR_QUEUE_SIZE
+#else
+#define QUEUE_SIZE 16
+#endif
+
+#define MSG_LEN 64
+
+typedef struct {
+    int  code;
+    char message[MSG_LEN];
+} err_entry_t;
+
+static err_entry_t       s_queue[QUEUE_SIZE];
+static int               s_head  = 0;  // next entry to pop (oldest)
+static int               s_tail  = 0;  // next slot to write
+static int               s_count = 0;
+static SemaphoreHandle_t s_mutex = NULL;
+
+void carbon_error_queue_init(void)
+{
+    if (s_mutex != NULL) return;
+    s_mutex = xSemaphoreCreateMutex();
+    if (s_mutex == NULL) {
+        ESP_LOGE(TAG, "Failed to create error queue mutex");
+        return;
+    }
+    s_head  = 0;
+    s_tail  = 0;
+    s_count = 0;
+    ESP_LOGI(TAG, "Error queue initialised (size %d)", QUEUE_SIZE);
+}
+
+void carbon_push_error(int code, const char *message)
+{
+    if (s_mutex == NULL) return;
+    if (message == NULL) message = "";
+
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+
+    if (s_count == QUEUE_SIZE) {
+        s_head = (s_head + 1) % QUEUE_SIZE;
+        s_count--;
+        ESP_LOGW(TAG, "Error queue full — oldest entry discarded");
+    }
+
+    s_queue[s_tail].code = code;
+    strncpy(s_queue[s_tail].message, message, MSG_LEN - 1);
+    s_queue[s_tail].message[MSG_LEN - 1] = '\0';
+    s_tail  = (s_tail + 1) % QUEUE_SIZE;
+    s_count++;
+
+    xSemaphoreGive(s_mutex);
+}
+
+int carbon_pop_error(char *buf, size_t buf_len)
+{
+    if (s_mutex == NULL || buf == NULL || buf_len == 0) return 0;
+
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+
+    int ret;
+    if (s_count == 0) {
+        ret = snprintf(buf, buf_len, "0,\"No error\"");
+    } else {
+        int  code = s_queue[s_head].code;
+        char msg[MSG_LEN];
+        strncpy(msg, s_queue[s_head].message, MSG_LEN - 1);
+        msg[MSG_LEN - 1] = '\0';
+        s_head  = (s_head + 1) % QUEUE_SIZE;
+        s_count--;
+        ret = snprintf(buf, buf_len, "%d,\"%s\"", code, msg);
+    }
+
+    xSemaphoreGive(s_mutex);
+
+    if (ret < 0) {
+        buf[0] = '\0';
+        return 0;
+    }
+    return ret < (int)buf_len ? ret : (int)buf_len - 1;
+}
+
+int carbon_error_count(void)
+{
+    if (s_mutex == NULL) return 0;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    int n = s_count;
+    xSemaphoreGive(s_mutex);
+    return n;
+}
+
+void carbon_clear_errors(void)
+{
+    if (s_mutex == NULL) return;
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    s_head  = 0;
+    s_tail  = 0;
+    s_count = 0;
+    xSemaphoreGive(s_mutex);
+}

--- a/components/carbon_instrument/carbon_instrument.c
+++ b/components/carbon_instrument/carbon_instrument.c
@@ -1,4 +1,5 @@
 #include "carbon_instrument.h"
+#include "carbon_error_queue.h"
 #include "hislip_server.h"
 #include "mdns_service.h"
 #include "mdns_debug.h"
@@ -65,6 +66,7 @@ extern void scpi_uart_init(void);
 
 void carbon_instrument_start(void)
 {
+    carbon_error_queue_init();
     ESP_LOGI(TAG, "Registering built-in commands");
     scpi_standard_init();
     scpi_system_init();

--- a/components/carbon_instrument/carbon_param_parser.c
+++ b/components/carbon_instrument/carbon_param_parser.c
@@ -1,4 +1,5 @@
 #include "carbon_param_parser.h"
+#include "carbon_error_queue.h"
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -80,6 +81,7 @@ int carbon_parse_params(const char *cmd_tail,
             } else {
                 snprintf(response_buf, response_max,
                          "ERR:1:missing required parameter '%s'", d->name);
+                carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                 return -1;
             }
         }
@@ -95,12 +97,14 @@ int carbon_parse_params(const char *cmd_tail,
                     snprintf(response_buf, response_max,
                              "ERR:2:parameter '%s': expected integer, got '%s'",
                              d->name, token);
+                    carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                     return -1;
                 }
                 if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
                     snprintf(response_buf, response_max,
                              "ERR:3:parameter '%s': %ld out of range [%.0f, %.0f]",
                              d->name, v, d->min, d->max);
+                    carbon_push_error(CARBON_ERR_PARAM_OUT_OF_RANGE, response_buf);
                     return -1;
                 }
                 out[i].int_val = (int)v;
@@ -113,12 +117,14 @@ int carbon_parse_params(const char *cmd_tail,
                     snprintf(response_buf, response_max,
                              "ERR:2:parameter '%s': expected float, got '%s'",
                              d->name, token);
+                    carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                     return -1;
                 }
                 if (d->max > d->min && ((double)v < d->min || (double)v > d->max)) {
                     snprintf(response_buf, response_max,
                              "ERR:3:parameter '%s': %g out of range [%g, %g]",
                              d->name, (double)v, d->min, d->max);
+                    carbon_push_error(CARBON_ERR_PARAM_OUT_OF_RANGE, response_buf);
                     return -1;
                 }
                 out[i].float_val = v;
@@ -136,6 +142,7 @@ int carbon_parse_params(const char *cmd_tail,
                     snprintf(response_buf, response_max,
                              "ERR:2:parameter '%s': expected boolean (0/1/true/false/on/off),"
                              " got '%s'", d->name, token);
+                    carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                     return -1;
                 }
                 out[i].bool_val = bv;
@@ -146,6 +153,7 @@ int carbon_parse_params(const char *cmd_tail,
                 if (scratch_used + len > scratch_len) {
                     snprintf(response_buf, response_max,
                              "ERR:2:parameter '%s': string too long", d->name);
+                    carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                     return -1;
                 }
                 memcpy(str_scratch + scratch_used, token, len);
@@ -172,6 +180,7 @@ int carbon_parse_params(const char *cmd_tail,
                     snprintf(response_buf, response_max,
                              "ERR:2:parameter '%s': expected %s, got '%s'",
                              d->name, valid, token);
+                    carbon_push_error(CARBON_ERR_INVALID_PARAM, response_buf);
                     return -1;
                 }
                 out[i].int_val = matched;

--- a/components/carbon_instrument/include/carbon_error_queue.h
+++ b/components/carbon_instrument/include/carbon_error_queue.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <stddef.h>
+
+// Standard SCPI error codes (IEEE 488.2 §21.8)
+#define CARBON_ERR_UNDEFINED_COMMAND   (-100)
+#define CARBON_ERR_INVALID_PARAM       (-200)
+#define CARBON_ERR_PARAM_OUT_OF_RANGE  (-222)
+#define CARBON_ERR_HARDWARE            (-300)
+
+// Must be called once from carbon_instrument_start() before any handler can run.
+// Idempotent — safe to call more than once.
+void carbon_error_queue_init(void);
+
+// Push an error onto the queue. Thread-safe. If the queue is full the oldest
+// entry is silently overwritten. message may not be NULL.
+void carbon_push_error(int code, const char *message);
+
+// Pop the oldest error and format the SCPI wire response into buf:
+//   error present → "-200,\"Invalid parameter\""
+//   queue empty   → "0,\"No error\""
+// Returns bytes written (excluding NUL), like snprintf.
+int carbon_pop_error(char *buf, size_t n);
+
+// Return current number of entries in the queue.
+int carbon_error_count(void);
+
+// Discard all queued errors. Called by *CLS.
+void carbon_clear_errors(void);

--- a/components/carbon_instrument/scpi_parser.c
+++ b/components/carbon_instrument/scpi_parser.c
@@ -1,6 +1,7 @@
 #include "scpi_parser.h"
 #include "scpi_watchdog.h"
 #include "carbon_registry.h"
+#include "carbon_error_queue.h"
 #include <string.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -55,5 +56,6 @@ int scpi_parse_command(const char *cmd_str, char *response_buf, size_t response_
     }
 
     snprintf(response_buf, response_max_len, "ERROR: Unknown command");
+    carbon_push_error(CARBON_ERR_UNDEFINED_COMMAND, "Undefined header");
     return strlen(response_buf);
 }

--- a/components/carbon_instrument/scpi_standard.c
+++ b/components/carbon_instrument/scpi_standard.c
@@ -1,4 +1,5 @@
 #include "carbon_instrument.h"
+#include "carbon_error_queue.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
@@ -32,6 +33,7 @@ static int cls_handler(const char *cmd, char *r, size_t n)
     if (s_status_byte != NULL) {
         *s_status_byte = 0;
     }
+    carbon_clear_errors();
     snprintf(r, n, "OK");
     return strlen(r);
 }

--- a/components/carbon_instrument/scpi_system.c
+++ b/components/carbon_instrument/scpi_system.c
@@ -1,5 +1,6 @@
 #include "carbon_instrument.h"
 #include "carbon_registry.h"
+#include "carbon_error_queue.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
@@ -54,6 +55,17 @@ static int jw_dbl(char *buf, size_t *pos, size_t max, double val)
 #define JW_STR(s)  do { if (jw_str(buf, &pos, n, s)    < 0) goto trunc; } while (0)
 #define JW_INT(v)  do { if (jw_dbl(buf, &pos, n, (double)(v)) < 0) goto trunc; } while (0)
 #define JW_DBL(v)  do { if (jw_dbl(buf, &pos, n, v)    < 0) goto trunc; } while (0)
+
+static int error_query_handler(const char *cmd, char *r, size_t n)
+{
+    return carbon_pop_error(r, n);
+}
+
+static int error_count_handler(const char *cmd, char *r, size_t n)
+{
+    snprintf(r, n, "%d", carbon_error_count());
+    return (int)strlen(r);
+}
 
 static int commands_handler(const char *cmd, char *r, size_t n)
 {
@@ -122,15 +134,37 @@ trunc:
 
 void scpi_system_init(void)
 {
-    static const carbon_cmd_descriptor_t cmd = {
-        .scpi_command = "SYSTEM:COMMANDS?",
-        .type         = CARBON_CMD_QUERY,
-        .group        = "System",
-        .description  = "Return all registered commands and device identity as JSON",
-        .param_count  = 0,
-        .timeout_ms   = 2000,
-        .handler      = commands_handler,
+    static const carbon_cmd_descriptor_t cmds[] = {
+        {
+            .scpi_command = "SYST:ERR?",
+            .type         = CARBON_CMD_QUERY,
+            .group        = "System",
+            .description  = "Pop oldest error from queue",
+            .param_count  = 0,
+            .timeout_ms   = 500,
+            .handler      = error_query_handler,
+        },
+        {
+            .scpi_command = "SYST:ERR:COUN?",
+            .type         = CARBON_CMD_QUERY,
+            .group        = "System",
+            .description  = "Return error queue depth",
+            .param_count  = 0,
+            .timeout_ms   = 500,
+            .handler      = error_count_handler,
+        },
+        {
+            .scpi_command = "SYSTEM:COMMANDS?",
+            .type         = CARBON_CMD_QUERY,
+            .group        = "System",
+            .description  = "Return all registered commands and device identity as JSON",
+            .param_count  = 0,
+            .timeout_ms   = 2000,
+            .handler      = commands_handler,
+        },
     };
-    carbon_register_command(&cmd);
+    for (size_t i = 0; i < sizeof(cmds) / sizeof(cmds[0]); i++) {
+        carbon_register_command(&cmds[i]);
+    }
     ESP_LOGI(TAG, "System commands registered");
 }

--- a/test_hislip_client.py
+++ b/test_hislip_client.py
@@ -161,6 +161,32 @@ def test_errors(c: HiSLIPClient):
     check("Command too long", c.send("A" * 300),    "ERROR")
 
 
+def test_error_queue(c: HiSLIPClient):
+    print("\n── SCPI Error Queue ──")
+
+    # Start with a clean slate
+    c.send("*CLS")
+    check("SYST:ERR? (empty queue)",    c.send("SYST:ERR?"),       '0,"No error"')
+    check("SYST:ERR:COUN? (empty)",     c.send("SYST:ERR:COUN?"),  "0")
+
+    # Unknown command should push CARBON_ERR_UNDEFINED_COMMAND (-100)
+    c.send("NOTACOMMAND_ERRTEST")
+    check("SYST:ERR:COUN? after unknown cmd", c.send("SYST:ERR:COUN?"), "1")
+    check("SYST:ERR? pops -100 error",        c.send("SYST:ERR?"),      "-100,")
+
+    # Queue empty again after the pop
+    check("SYST:ERR? after pop (empty)", c.send("SYST:ERR?"), '0,"No error"')
+
+    # *CLS must clear the queue
+    c.send("NOTACOMMAND_ERRTEST")
+    c.send("NOTACOMMAND_ERRTEST")
+    count = c.send("SYST:ERR:COUN?")
+    ok = count == "2"
+    print(f"  [{'PASS' if ok else 'FAIL'}] COUN? after 2 errors: {count!r}  (expected '2')")
+    c.send("*CLS")
+    check("SYST:ERR:COUN? after *CLS", c.send("SYST:ERR:COUN?"), "0")
+
+
 # ── Main ──────────────────────────────────────────────────────────────────────
 
 def main():
@@ -181,6 +207,7 @@ def main():
         test_adc(c)
         test_introspection(c)
         test_errors(c)
+        test_error_queue(c)
         print("\n" + "=" * 55)
         print(" Done")
         print("=" * 55)

--- a/tools/generate_profile.py
+++ b/tools/generate_profile.py
@@ -97,8 +97,10 @@ _RESPONSE_TYPES: dict = {
     "*OPC?":     "bool",   # completion flag — always returns 1 when pending ops finish
     "*ESR?":     "int",
     "*ESE?":     "int",
-    "UART:READ?": "enum",   # received bytes returned as text
-    "GPIO:GET?":  "bool",   # digital pin level: 0 (low) or 1 (high)
+    "UART:READ?":     "enum",   # received bytes returned as text
+    "GPIO:GET?":      "bool",   # digital pin level: 0 (low) or 1 (high)
+    "SYST:ERR?":      "enum",   # returns code,"message" e.g. 0,"No error"
+    "SYST:ERR:COUN?": "int",    # queue depth
 }
 
 _RESPONSE_UNITS: dict = {


### PR DESCRIPTION
Closes #12.

## Summary

- Adds `carbon_error_queue.c/h`: 16-entry static circular buffer (Kconfig-tunable 4–64), FreeRTOS mutex, idempotent init
- Registers `SYST:ERR?` (pop oldest, returns `code,"message"` or `0,"No error"`) and `SYST:ERR:COUN?` in `scpi_system.c`
- `*CLS` now clears the error queue per IEEE 488.2 §10.3
- All 8 parameter validation failure sites in `carbon_param_parser.c` push to the queue (`-200` type/enum/string errors, `-222` out-of-range)
- Unknown commands in `scpi_parser.c` push `-100,"Undefined header"`
- `generate_profile.py` maps `SYST:ERR?`→`enum` and `SYST:ERR:COUN?`→`int` in `_RESPONSE_TYPES`
- `test_hislip_client.py` adds `test_error_queue()` covering empty queue, unknown-command push, single pop, count assertion, and `*CLS` clear

## Test plan

- [ ] Flash firmware and run `python test_hislip_client.py <host>` — `test_error_queue` suite should pass
- [ ] `SYST:ERR?` on empty queue returns `0,"No error"`
- [ ] Unknown command pushes `-100` error, readable via `SYST:ERR?`
- [ ] `SYST:ERR:COUN?` returns `2` after two unknown commands
- [ ] `*CLS` resets count to `0`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)