### PR TITLE
Add protocol and defaultAddress to generated connection block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 GitHub: `applied-research-and-computing/esp32-sdk`
 
+The remote is aliased as `db`, not `origin`. Use `git push db <branch>` etc.
+
+## Branches
+
+Work addressing a GitHub issue must be done on a branch named `fix/<description>` (bug fixes) or `feat/<description>` (new features). Push with `git push -u db <branch>` and open PRs against `main`.
+
 ## Commits and Pull Requests
 
 Never include internal or confidential information in commit messages, PR titles, PR descriptions, or code comments — this repository is public. This covers things like internal hostnames, IP addresses, network credentials, organizational details, personal contact information, or proprietary system names that don't belong in a public SDK.

--- a/tools/generate_profile.py
+++ b/tools/generate_profile.py
@@ -182,7 +182,8 @@ def _qs(val: str) -> str:
 
 # ── YAML renderer ─────────────────────────────────────────────────────────────
 
-def generate_yaml(identity: dict, commands: list, hostname: str, port: int = 4880) -> str:
+def generate_yaml(identity: dict, commands: list, hostname: str, port: int = 4880,
+                  default_address: Optional[str] = None) -> str:
     manufacturer = identity.get("manufacturer", "UNKNOWN")
     model        = identity.get("model",         "UNKNOWN")
     serial       = identity.get("serial",        "")
@@ -217,6 +218,9 @@ def generate_yaml(identity: dict, commands: list, hostname: str, port: int = 488
     ln("  bus:")
     ln("    - type: lan")
     ln(f"      defaultPort: {port}")
+    ln("      protocol: hislip")
+    if default_address:
+        ln(f"      defaultAddress: {default_address}")
     ln("      timeout: 5000")
     ln()
 
@@ -322,9 +326,11 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate a Carbon profile.yaml from a live ESP32 instrument."
     )
-    parser.add_argument("--host",   required=True, help="Device hostname or IP address")
-    parser.add_argument("--port",   type=int, default=4880, help="HiSLIP port (default 4880)")
-    parser.add_argument("--output", default="-",
+    parser.add_argument("--host",     required=True, help="Device hostname or IP address")
+    parser.add_argument("--port",     type=int, default=4880, help="HiSLIP port (default 4880)")
+    parser.add_argument("--hostname", default=None,
+                        help="mDNS hostname to embed as defaultAddress (e.g. carbon-esp32.local)")
+    parser.add_argument("--output",   default="-",
                         help="Output file path, or - for stdout (default: -)")
     args = parser.parse_args()
 
@@ -355,7 +361,7 @@ def main() -> None:
     print(f"Received {len(commands)} commands.", file=sys.stderr)
 
     # Generate
-    yaml_out = generate_yaml(identity, commands, args.host, args.port)
+    yaml_out = generate_yaml(identity, commands, args.host, args.port, args.hostname)
 
     # Write
     if args.output == "-":


### PR DESCRIPTION
## Summary

- Adds `protocol: hislip` to the `bus` entry in the generated `connection` block — profiles were missing this field and required manual editing after generation
- Adds `--hostname` CLI flag; when supplied, emits `defaultAddress` in the bus entry (e.g. `carbon-esp32-inst-531c.local`)
- Documents the `db` remote alias and `fix/`/`feat/` branch naming convention in `CLAUDE.md`

Closes #14

## Test plan

- [ ] Run `python tools/generate_profile.py --host <device>` and confirm `protocol: hislip` appears in the `connection` block
- [ ] Run with `--hostname carbon-esp32.local` and confirm `defaultAddress: carbon-esp32.local` appears
- [ ] Run without `--hostname` and confirm `defaultAddress` is absent (no empty field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)